### PR TITLE
fix(path): joining an absolute path fragment with another incorrectly removes the first slash from the resulting url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ export function relativeToFile(name, file){
 }
 
 export function join(path1, path2) {
-  var url1, url2, url3, i, ii;
+  var url1, url2, url3, i, ii, urlPrefix;
 
   if(!path1){
     return path2;
@@ -54,6 +54,8 @@ export function join(path1, path2) {
   if(!path2){
     return path1;
   }
+  
+  urlPrefix = path1.indexOf('/') === 0 ? '/' : '';
 
   url1 = path1.split('/');
   url2 = path2.split('/');
@@ -79,5 +81,5 @@ export function join(path1, path2) {
     }
   }
 
-  return url3.join('/').replace(/\:\//g, '://');;
+  return urlPrefix + url3.join('/').replace(/\:\//g, '://');;
 }

--- a/test/path.spec.js
+++ b/test/path.spec.js
@@ -46,13 +46,41 @@ describe('join', () => {
   });
 
   it('can combine an absolute path and a simple path', () => {
+    var path1 = '/one';
+    var path2 = 'two';
+
+    expect(join(path1, path2)).toBe('/one/two');
+  });
+
+  it('can combine an absolute path and a simple path with slash', () => {
+    var path1 = '/one';
+    var path2 = '/two';
+
+    expect(join(path1, path2)).toBe('/one/two');
+  });
+
+  it('can combine a single slash and a simple path', () => {
+    var path1 = '/';
+    var path2 = 'two';
+
+    expect(join(path1, path2)).toBe('/two');
+  });
+
+  it('can combine a single slash and a simple path with slash', () => {
+    var path1 = '/';
+    var path2 = '/two';
+
+    expect(join(path1, path2)).toBe('/two');
+  });
+
+  it('can combine an absolute path with protocol and a simple path', () => {
     var path1 = 'http://durandal.io';
     var path2 = 'two';
 
     expect(join(path1, path2)).toBe('http://durandal.io/two');
   });
 
-  it('can combine an absolute path and a simple path with slash', () => {
+  it('can combine an absolute path with protocol and a simple path with slash', () => {
     var path1 = 'http://durandal.io';
     var path2 = '/two';
 


### PR DESCRIPTION
The path are joined incorrectly in the following scenario (the first slash gets removed):

    join('/base', 'path')
    join('/base', '/path')

Expected:

    /base/path

Actual result

    base/path