### PR TITLE
fix(path): Join protocol independent paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,8 @@ export function join(path1, path2) {
     return path1;
   }
 
-  urlPrefix = path1.indexOf('/') === 0 ? '/' : '';
+  urlPrefix = path1.indexOf('//') === 0 ? '//' :
+              path1.indexOf('/') === 0 ? '/' : '';
 
   url1 = path1.split('/');
   url2 = path2.split('/');

--- a/test/path.spec.js
+++ b/test/path.spec.js
@@ -108,6 +108,34 @@ describe('join', () => {
     expect(join(path1, path2)).toBe('http://durandal.io/two');
   });
 
+  it('can combine a protocol independent path and a simple path', () => {
+    var path1 = '//durandal.io';
+    var path2 = 'two';
+
+    expect(join(path1, path2)).toBe('//durandal.io/two');
+  });
+
+  it('can combine a protocol independent path and a simple path with slash', () => {
+    var path1 = '//durandal.io';
+    var path2 = '/two';
+
+    expect(join(path1, path2)).toBe('//durandal.io/two');
+  });
+
+  it('can combine a protocol independent path and a simple path with a dot', () => {
+    var path1 = '//durandal.io';
+    var path2 = './two';
+
+    expect(join(path1, path2)).toBe('//durandal.io/two');
+  });
+
+  it('can combine a protocol independent path and a relative path', () => {
+    var path1 = '//durandal.io/somewhere';
+    var path2 = '../two';
+
+    expect(join(path1, path2)).toBe('//durandal.io/two');
+  });
+
   it('can combine a complex path and a relative path', () => {
     var path1 = 'one/three';
     var path2 = '../two';


### PR DESCRIPTION
Protocol independent paths (e.g. `//host.com/path`) are being treated as relative paths.

`join('//host.com', 'path')`

Expected `//host.com/path`
Actual `/host.com/path`