### PR TITLE
fix(join): respect file protocol with empty host

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,8 +48,14 @@ export function join(path1: string, path2: string): string {
     return path1;
   }
 
+  let schemeMatch = path1.match(/^([^/]*?:)\//);
+  let scheme = (schemeMatch && schemeMatch.length > 0) ? schemeMatch[1] : '';
+  path1 = path1.substr(scheme.length);
+
   let urlPrefix;
-  if (path1.indexOf('//') === 0) {
+  if (path1.indexOf('///') === 0 && scheme === 'file:') {
+    urlPrefix = '///';
+  } else if (path1.indexOf('//') === 0) {
     urlPrefix = '//';
   } else if (path1.indexOf('/') === 0) {
     urlPrefix = '/';
@@ -83,7 +89,7 @@ export function join(path1: string, path2: string): string {
     }
   }
 
-  return urlPrefix + url3.join('/').replace(/\:\//g, '://') + trailingSlash;
+  return scheme + urlPrefix + url3.join('/') + trailingSlash;
 }
 
 

--- a/test/path.spec.js
+++ b/test/path.spec.js
@@ -170,11 +170,40 @@ describe('join', () => {
 
     expect(join(path1, path2)).toBe('one');
   });
+
   it('should respect a trailing slash', () => {
     var path1 = 'one/';
     var path2 = 'two/';
 
     expect(join(path1, path2)).toBe('one/two/');
+  });
+
+  it('should respect file:/// protocol with three slashes (empty host)', () => {
+    var path1 = 'file:///one';
+    var path2 = '/two';
+
+    expect(join(path1, path2)).toBe('file:///one/two');
+  });
+
+  it('should respect file:// protocol with two slashes (host given)', () => {
+    var path1 = 'file://localhost:8080';
+    var path2 = '/two';
+
+    expect(join(path1, path2)).toBe('file://localhost:8080/two');
+  });
+
+  it('should allow scheme-relative URL that uses colons in the path', () => {
+    var path1 = '//localhost/one:/';
+    var path2 = '/two';
+
+    expect(join(path1, path2)).toBe('//localhost/one:/two');
+  });
+
+  it('should not add more than two leading slashes to http:// protocol', () => {
+    var path1 = 'http:///';
+    var path2 = '/two';
+
+    expect(join(path1, path2)).toBe('http://two');
   });
 });
 


### PR DESCRIPTION
This allows using Aurelia with SystemJS in Cordova/PhoneGap.

SystemJS doesn't detect some of the already loaded modules from templating-resources and templating-router and tries to load them again, because it compares normalized module IDs starting with `file:///jspm_packages/...` with `file://jspm_packages/...` (notice that one slash is removed by aurelia-path's `join(path1, path2)` method).

![load_failure](https://cloud.githubusercontent.com/assets/646530/9340184/9b39150a-45ee-11e5-913d-45ffd15d5fda.png)

According to [RFC 1738](http://www.ietf.org/rfc/rfc1738.txt) `localhost` can be omitted for file URL schemes, which results in `file:///jspm_package/...`.