### PR TITLE
Fix for query string return true for param with equal sign on the end

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -241,7 +241,7 @@ export function parseQueryString(queryString: string): Object {
       keysLastIndex = 0;
     }
 
-    if (pair.length === 2) {
+    if (pair.length >= 2) {
       let value = pair[1] ? decodeURIComponent(pair[1]) : '';
       if (keysLastIndex) {
         parseComplexParam(queryParams, keys, value);

--- a/test/path.spec.js
+++ b/test/path.spec.js
@@ -252,6 +252,9 @@ describe('query strings', () => {
     expect(parse('a=b&c=d')).toEqual({ a: 'b', c: 'd' });
     expect(parse('a=b&&c=d')).toEqual({ a: 'b', c: 'd' });
     expect(parse('a=b&a=c')).toEqual({ a: 'c' });
+    
+    expect(parse('a=b&c=d=')).toEqual({ a: 'b', c: 'd' });
+    expect(parse('a=b&c=d==')).toEqual({ a: 'b', c: 'd' });
 
     expect(parse('a=%26')).toEqual({ a: '&' });
     expect(parse('%26=a')).toEqual({ '&': 'a' });


### PR DESCRIPTION
When parameter value ends with  '==' or '=' (base64 encoded value) it returns true instead of the actual value

Example
http://localhost:9000#/?AccessCode=60CF38Ey7v2Q1rN295O4BdmiAJs3t1PFXvSFBBySNcCd2a6lbQy9gXn6MfjC5iuK6ZrA3nwcP3TjdtVo1AjgvBRhkaIQKK4_w5mkxPhVkZcRkkWgApxsXq5t1P_Q3-Le1WI17zpvQEX28hylrLM1x6n9U0g==

Actual
Access Code = true
Expected
Access Code = 60CF38Ey7v2Q1rN295O4BdmiAJs3t1PFXvSFBBySNcCd2a6lbQy9gXn6MfjC5iuK6ZrA3nwcP3TjdtVo1AjgvBRhkaIQKK4_w5mkxPhVkZcRkkWgApxsXq5t1P_Q3-Le1WI17zpvQEX28hylrLM1x6n9U0g
(without the equal signs)