### PR TITLE
Build and parse queries also in traditional style

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,19 +113,24 @@ let encodeKey = k => encode(k).replace('%24', '$');
 *
 * @param key Parameter name for query string.
 * @param value Parameter value to deserialize.
+* @param traditional Boolean Use the old URI template standard (RFC6570)
 * @return Array with serialized parameter(s)
 */
-function buildParam(key: string, value: any): Array<string> {
+function buildParam(key: string, value: any, traditional: boolean): Array<string> {
   let result = [];
   if (value === null || value === undefined) {
     return result;
   }
   if (Array.isArray(value)) {
     for (let i = 0, l = value.length; i < l; i++) {
-      let arrayKey = key + '[' + (typeof value[i] === 'object' && value[i] !== null ? i : '') + ']';
-      result = result.concat(buildParam(arrayKey, value[i]));
+      if (traditional) {
+        result.push(`${encodeKey(key)}=${encode(value[i])}`);
+      } else {
+        let arrayKey = key + '[' + (typeof value[i] === 'object' && value[i] !== null ? i : '') + ']';
+        result = result.concat(buildParam(arrayKey, value[i]));
+      }
     }
-  } else if (typeof (value) === 'object') {
+  } else if (typeof (value) === 'object' && !traditional) {
     for (let propertyName in value) {
       result = result.concat(buildParam(key + '[' + propertyName + ']', value[propertyName]));
     }
@@ -139,14 +144,15 @@ function buildParam(key: string, value: any): Array<string> {
 * Generate a query string from an object.
 *
 * @param params Object containing the keys and values to be used.
+* @param traditional Boolean Use the old URI template standard (RFC6570)
 * @returns The generated query string, excluding leading '?'.
 */
-export function buildQueryString(params: Object): string {
+export function buildQueryString(params: Object, traditional: Boolean): string {
   let pairs = [];
   let keys = Object.keys(params || {}).sort();
   for (let i = 0, len = keys.length; i < len; i++) {
     let key = keys[i];
-    pairs = pairs.concat(buildParam(key, params[key]));
+    pairs = pairs.concat(buildParam(key, params[key], traditional));
   }
 
   if (pairs.length === 0) {
@@ -161,10 +167,9 @@ export function buildQueryString(params: Object): string {
 *
 * @param existedParam Object with previously parsed values for specified key.
 * @param value Parameter value to append.
-* @param isPrimitive If true and parameter value already specified - method overwrites it. If false - transofrm parameter to array and append new value to it.
 * @returns Initial primitive value or transformed existedParam if parameter was recognized as an array.
 */
-function processScalarParam(existedParam: Object, value: Object, isPrimitive: boolean): Object {
+function processScalarParam(existedParam: Object, value: Object): Object {
   if (Array.isArray(existedParam)) {
     // value is already an array, so push on the next value.
     existedParam.push(value);
@@ -173,7 +178,7 @@ function processScalarParam(existedParam: Object, value: Object, isPrimitive: bo
   if (existedParam !== undefined) {
     // value isn't an array, but since a second value has been specified,
     // convert value into an array.
-    return isPrimitive ? value : [existedParam, value];
+    return [existedParam, value];
   }
   // value is a scalar.
   return value;
@@ -193,7 +198,10 @@ function parseComplexParam(queryParams: Object, keys: Object, value: any): void 
   for (let j = 0; j <= keysLastIndex; j++) {
     let key = keys[j] === '' ? currentParams.length : keys[j];
     if (j < keysLastIndex) {
-      currentParams = currentParams[key] = currentParams[key] || (isNaN(keys[j + 1]) ? {} : []);
+      // The value has to be an array or a false value
+      // It can happen that the value is no array if the key was repeated with traditional style like `list=1&list[]=2`
+      let prevValue = !currentParams[key] || typeof currentParams[key] === 'object' ? currentParams[key] : [currentParams[key]];
+      currentParams = currentParams[key] = prevValue || (isNaN(keys[j + 1]) ? {} : []);
     } else {
       currentParams = currentParams[key] = value;
     }
@@ -222,7 +230,6 @@ export function parseQueryString(queryString: string): Object {
   for (let i = 0; i < pairs.length; i++) {
     let pair = pairs[i].split('=');
     let key = decodeURIComponent(pair[0]);
-    let isPrimitive = false;
     if (!key) {
       continue;
     }
@@ -238,7 +245,6 @@ export function parseQueryString(queryString: string): Object {
       keys = keys.shift().split('[').concat(keys);
       keysLastIndex = keys.length - 1;
     } else {
-      isPrimitive = true;
       keysLastIndex = 0;
     }
 
@@ -247,7 +253,7 @@ export function parseQueryString(queryString: string): Object {
       if (keysLastIndex) {
         parseComplexParam(queryParams, keys, value);
       } else {
-        queryParams[key] = processScalarParam(queryParams[key], value, isPrimitive);
+        queryParams[key] = processScalarParam(queryParams[key], value);
       }
     } else {
       queryParams[key] = true;

--- a/test/path.spec.js
+++ b/test/path.spec.js
@@ -219,10 +219,14 @@ describe('query strings', () => {
     expect(gen({ '': 'a' })).toBe('=a');
     expect(gen({ a: 'b' })).toBe('a=b');
     expect(gen({ a: 'b', c: 'd' })).toBe('a=b&c=d');
+    expect(gen({ a: 'b', c: 'd' }, true)).toBe('a=b&c=d');
     expect(gen({ a: 'b', c: null })).toBe('a=b');
+    expect(gen({ a: 'b', c: null }, true)).toBe('a=b');
 
     expect(gen({ a: ['b', 'c'] })).toBe('a%5B%5D=b&a%5B%5D=c');
+    expect(gen({ a: ['b', 'c'] }, true)).toBe('a=b&a=c');
     expect(gen({ '&': ['b', 'c'] })).toBe('%26%5B%5D=b&%26%5B%5D=c');
+    expect(gen({ '&': ['b', 'c'] }, true)).toBe('%26=b&%26=c');
 
     expect(gen({ a: '&' })).toBe('a=%26');
     expect(gen({ '&': 'a' })).toBe('%26=a');
@@ -230,9 +234,13 @@ describe('query strings', () => {
     expect(gen({ '$test': true })).toBe('$test=true');
 
     expect(gen({ obj: { a: 5, b: "str", c: false } })).toBe('obj%5Ba%5D=5&obj%5Bb%5D=str&obj%5Bc%5D=false');
+    expect(gen({ obj: { a: 5, b: "str", c: false } }, true)).toBe('obj=%5Bobject%20Object%5D');
     expect(gen({ obj:{ a: 5, b: undefined}})).toBe('obj%5Ba%5D=5');
         
     expect(gen({a: {b: ['c','d', ['f', 'g']]}})).toBe('a%5Bb%5D%5B%5D=c&a%5Bb%5D%5B%5D=d&a%5Bb%5D%5B2%5D%5B%5D=f&a%5Bb%5D%5B2%5D%5B%5D=g');
+    expect(gen({a: {b: ['c','d', ['f', 'g']]}}, true)).toBe('a=%5Bobject%20Object%5D');
+    expect(gen({a: ['c','d', ['f', 'g']]}, true)).toBe('a=c&a=d&a=f%2Cg');
+    expect(gen({a: ['c','d', {f: 'g'}]}, true)).toBe('a=c&a=d&a=%5Bobject%20Object%5D');
   });
 
   it('should parse query strings', () => {
@@ -251,7 +259,7 @@ describe('query strings', () => {
     expect(parse('a=b')).toEqual({ a: 'b' });
     expect(parse('a=b&c=d')).toEqual({ a: 'b', c: 'd' });
     expect(parse('a=b&&c=d')).toEqual({ a: 'b', c: 'd' });
-    expect(parse('a=b&a=c')).toEqual({ a: 'c' });
+    expect(parse('a=b&a=c')).toEqual({ a: ['b', 'c'] });
     
     expect(parse('a=b&c=d=')).toEqual({ a: 'b', c: 'd' });
     expect(parse('a=b&c=d==')).toEqual({ a: 'b', c: 'd' });


### PR DESCRIPTION
#### Purpose:
Some frameworks and libraries still doesn't support the modern style of query string in URI's. The RFC6570 standard describes the traditional way for URI templates. This PR intends to make the functions `buildQueryString` and `parseQueryString` able to handle those traditional style.

#### What I did:
Regarding the issue #21 I added a optional flag to the `buildQueryString` function to either build the query in the traditional rfc 6570 standard or in the modern style. The modern style is the default to don't implement changes for existing users.

In the rfc 6570 standard is mentioned that a repeated parameter key doesn't override the value but indicates a list of values. Therefore I adjusted the parseQueryString behavior to don't override existing keys but wrap the value in an array.

#### Examples:
```js
buildQueryString({var: 1, list: [1, 2]}) === 'list=1&list=2&var=1'
buildQueryString({var: 1, obj: {asd: 1}, list: [1, 2, {asd: 23}]}) === 'list=1&list=2&list=[object Object]&obj=[object Object]&var=1'

parseQueryString('a=c&a=e') == {"a":["c","e"]}
parseQueryString('a=c&a[2]=e&a=d&a[]=f') == {"a":["c",null,"e","d","f"]}
```