### PR TITLE
parse query bug fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -249,7 +249,8 @@ export function parseQueryString(queryString: string): Object {
     }
 
     if (pair.length >= 2) {
-      let value = pair[1] ? decodeURIComponent(pair[1]) : '';
+      pair.shift();
+      let value = decodeURIComponent(pair.join('=')) || '';
       if (keysLastIndex) {
         parseComplexParam(queryParams, keys, value);
       } else {

--- a/test/path.spec.js
+++ b/test/path.spec.js
@@ -261,8 +261,8 @@ describe('query strings', () => {
     expect(parse('a=b&&c=d')).toEqual({ a: 'b', c: 'd' });
     expect(parse('a=b&a=c')).toEqual({ a: ['b', 'c'] });
     
-    expect(parse('a=b&c=d=')).toEqual({ a: 'b', c: 'd' });
-    expect(parse('a=b&c=d==')).toEqual({ a: 'b', c: 'd' });
+    expect(parse('a=b&c=d=')).toEqual({ a: 'b', c: 'd=' });
+    expect(parse('a=b&c=d==')).toEqual({ a: 'b', c: 'd==' });
 
     expect(parse('a=%26')).toEqual({ a: '&' });
     expect(parse('%26=a')).toEqual({ '&': 'a' });


### PR DESCRIPTION
Base64 encoded string has equal char (=).
So it must join with '=' before make a value.